### PR TITLE
fix compatibility with UTF8 CF_TEXT and some other issues

### DIFF
--- a/terminal.c
+++ b/terminal.c
@@ -3061,7 +3061,7 @@ static void do_osc(Terminal *term)
                                       }
                                       fmt = CF_UNICODETEXT;
 
-                                    } else if (fmt >= CF_UNICODETEXT || fmt >= 0xC000) {
+                                    } else if (fmt == CF_UNICODETEXT || fmt >= 0xC000) {
                                       // very stupid utf32->utf16 'conversion'
                                       buffer = calloc((len / sizeof(uint32_t)) + 1, sizeof(wchar_t));
                                       for (int i=0; i < len / sizeof(uint32_t); ++i) {


### PR DESCRIPTION
I plan to switch far2l TTY clipboard extension to UTF8 and will use CF_TEXT as format for this, so it will ba back-forward compatible with old far2l, but this patched putty needs some changes to be compatible with that...
Also added some checks for buffer sizes, simplified some things (like using calloc to allocate zero-inited memory instead of manually setting some values to zero)